### PR TITLE
Fixed 1.8 -> 1.7 update score translation

### DIFF
--- a/src/main/java/net/raphimc/vialegacy/protocols/release/protocol1_8to1_7_6_10/Protocol1_8to1_7_6_10.java
+++ b/src/main/java/net/raphimc/vialegacy/protocols/release/protocol1_8to1_7_6_10/Protocol1_8to1_7_6_10.java
@@ -1056,8 +1056,9 @@ public class Protocol1_8to1_7_6_10 extends AbstractProtocol<ClientboundPackets1_
             @Override
             public void register() {
                 map(Type.STRING); // name
+                map(Type.BYTE, Type.VAR_INT); // mode
                 handler(wrapper -> {
-                    final byte mode = wrapper.passthrough(Type.BYTE); // mode
+                    final int mode = wrapper.get(Type.VAR_INT, 0); // mode
                     if (mode == 0/*UPDATE*/) {
                         wrapper.passthrough(Type.STRING); // objective
                         wrapper.write(Type.VAR_INT, wrapper.read(Type.INT)); // score


### PR DESCRIPTION
This didn't caused any issues before because Via wasn't touching the data until https://github.com/ViaVersion/ViaVersion/blob/0392992173060a888d38c6aed97beefa7e43d461/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_3to1_20_2/Protocol1_20_3To1_20_2.java#L82 which will now cause issues with latest clients on older versions.

1.7 packet code:
![old_code](https://github.com/ViaVersion/ViaLegacy/assets/60033407/2cbbbca2-d328-4e26-a211-99f37c4c8a16)

1.8 packet code with enum reading:
![new_code](https://github.com/ViaVersion/ViaLegacy/assets/60033407/40ca4e65-e5f0-4633-a1a3-e96cc70ed044)
![enum_reading](https://github.com/ViaVersion/ViaLegacy/assets/60033407/39fe377f-2265-4e01-8279-8543e7d7174a)
